### PR TITLE
fix cask link for `1.0.0`

### DIFF
--- a/screentimelapse.rb
+++ b/screentimelapse.rb
@@ -2,7 +2,7 @@ cask "screentimelapse" do
   version "1.0.0"
   sha256 :no_check
 
-  url "https://github.com/wkaisertexas/ScreenTimeLapse/releases/download/v1.0.0/ScreenTimeLapse.zip"
+  url "https://github.com/wkaisertexas/ScreenTimeLapse/releases/download/v1.0.0/TimeLapze.zip"
   name "ScreenTimeLapse"
   desc "Record screen time lapses with ease in a simple, intuitive interface"
   homepage "https://github.com/wkaisertexas/ScreenTimeLapse"


### PR DESCRIPTION
This PR will fix the URL in brew cask recipe. Solves #20 